### PR TITLE
Adding put method with test

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,33 @@ const users = await client.post("users/lookup", {
 });
 ```
 
+### .put(endpoint, query_parameters, request_body)
+
+Same return as `.get()` and `.post()`.
+
+Use the `.put` method for actions that update state. For [example](https://developer.twitter.com/en/docs/direct-messages/welcome-messages/api-reference/update-welcome-message), to update a welcome message.
+
+```es6
+const client = new Twitter({
+  consumer_key: "xyz",
+  consumer_secret: "xyz",
+  access_token_key: "abc",
+  access_token_secret: "abc"
+});
+
+const welcomeMessageID = "abc"  
+
+await client.put("direct_messages/welcome_messages/update", {
+  id: welcomeMessageID
+}, 
+{
+  message_data: {
+    text: "Welcome!!!"
+  }
+}
+)
+```
+
 ### .getBearerToken()
 
 See the [app authentication example](#app-authentication-example).

--- a/test/twitter.test.js
+++ b/test/twitter.test.js
@@ -208,6 +208,39 @@ describe('posting', () => {
   });
 });
 
+describe('putting', () => {
+  let client;
+  beforeAll(() => client = newClient());
+  /**
+   * For this test you need to have opted to receive messages from anyone at https://twitter.com/settings/safety
+   * and your demo app needs to have access to read, write, and direct messages.
+   */
+  it('can update welcome message', async () => {
+    const newWelcomeMessage = await client.post('direct_messages/welcome_messages/new',
+      {
+        welcome_message: {
+          name: 'simple_welcome-message 01',
+          message_data: {
+            text: 'Welcome!',
+          },
+        },
+      },
+    );
+
+    const updatedWelcomeMessage = await client.put('direct_messages/welcome_messages/update', {
+      id: newWelcomeMessage.welcome_message.id,
+    },
+    {
+      message_data: {
+        text: 'Welcome!!!',
+      },
+    });
+
+    expect(updatedWelcomeMessage.welcome_message.message_data.text).toEqual('Welcome!!!');
+  });
+},
+);
+
 describe('misc', () => {
   let client;
   beforeAll(() => (client = newClient()));
@@ -219,12 +252,12 @@ describe('misc', () => {
     });
     // This is @naval's original tweet
     expect(response.retweeted_status.full_text).toEqual(
-      '@jdburns4 “Retirement” occurs when you stop sacrificing today for an imagined tomorrow. You can retire when your passive income exceeds your burn rate, or when you can make a living doing what you love.'
+      '@jdburns4 “Retirement” occurs when you stop sacrificing today for an imagined tomorrow. You can retire when your passive income exceeds your burn rate, or when you can make a living doing what you love.',
     );
     // For the retweet, "truncated" comes misleadingly set to "false" from the API, and the "full_text" is limited to 140 chars
     expect(response.truncated).toEqual(false);
     expect(response.full_text).toEqual(
-      'RT @naval: @jdburns4 “Retirement” occurs when you stop sacrificing today for an imagined tomorrow. You can retire when your passive income…'
+      'RT @naval: @jdburns4 “Retirement” occurs when you stop sacrificing today for an imagined tomorrow. You can retire when your passive income…',
     );
   });
 
@@ -304,3 +337,4 @@ describe('misc', () => {
     expect(response).toHaveLength(2);
   });
 });
+

--- a/twitter.js
+++ b/twitter.js
@@ -253,6 +253,34 @@ class Twitter {
   }
 
   /**
+   * Send a PUT request 
+   * @param {string} resource - endpoint e.g. `direct_messages/welcome_messages/update`
+   * @param {object} parameters - required or optional query parameters
+   * @param {object} body - PUT request body 
+   * @returns {Promise<object>} Promise resolving to the response from the Twitter API.
+   */
+  put(resource, parameters, body) {
+    const { requestData, headers } = this._makeRequest(
+      'PUT',
+      resource,
+      parameters
+    );
+
+    const putHeaders = Object.assign({}, baseHeaders, headers);
+    body = JSON.stringify(body);
+
+    return Fetch(requestData.url, {
+      method: 'PUT',
+      headers: putHeaders,
+      body,
+    })
+      .then(Twitter._handleResponse)
+      .then(results =>
+        'errors' in results ? Promise.reject(results) : results
+      );
+  }
+
+  /**
    *
    * @param {string} resource - endpoint, e.g. `statuses/filter`
    * @param {object} parameters


### PR DESCRIPTION
Fixes #39 

As far as I can tell, there is only one PUT endpoint located [here](https://developer.twitter.com/en/docs/direct-messages/welcome-messages/api-reference/update-welcome-message); thus, this is the only endpoint I am testing in `twitter.test.js`.

@peterpme I was a little unsure of why `es-lint` was adding a trailing comma to line 255 and 260 in `test/twitter.test.js`, but it seems like that's expected behavior for the `es-lint` config file at the project root. If these changes should not be included then please let me know and I'll remove them from the commit.

Once this PR gets merged I'll move on to #31 (DELETE). Thanks!