### PR TITLE
Fixing bundle and release scripts, simplify package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,12 +17,6 @@
     "Dan Dascalescu (https://github.com/dandv)"
   ],
   "license": "MIT",
-  "files": [
-    "twitter.js",
-    "stream.js",
-    "dist",
-    "index.d.ts"
-  ],
   "keywords": [
     "twitter",
     "rest",
@@ -51,7 +45,7 @@
   },
   "scripts": {
     "lint": "eslint ./",
-    "prepare": "microbundle",
+    "prepare": "microbundle --entry twitter.js",
     "test": "eslint . && jest --detectOpenHandles",
     "release": "npm run -s prepare && npm test && git tag $npm_package_version && git push && git push --tags && npm publish"
   },

--- a/package.json
+++ b/package.json
@@ -2,11 +2,7 @@
   "name": "twitter-lite",
   "version": "0.9.4",
   "description": "Tiny, full-featured client/server REST/stream library for the Twitter API",
-  "source": [
-    "twitter.js",
-    "stream.js",
-    "index.d.ts"
-  ],
+  "source": "twitter.js",
   "main": "dist/twitter.js",
   "module": "dist/twitter.m.js",
   "types": "dist/index.d.ts",
@@ -45,7 +41,7 @@
   },
   "scripts": {
     "lint": "eslint ./",
-    "prepare": "microbundle --entry twitter.js",
+    "prepare": "microbundle && cp index.d.ts dist/",
     "test": "eslint . && jest --detectOpenHandles",
     "release": "npm run -s prepare && npm test && git tag $npm_package_version && git push && git push --tags && npm publish"
   },


### PR DESCRIPTION
I wasn't sure what the "files" property in the `package.json` was doing, but it seems redundant (since we have `source`).

For reference, this is an example of all the minimal config that Microbundle needs (from their docs)

```
{
  "source": "src/foo.js",          // Your source file (same as 1st arg to microbundle)
  "main": "dist/foo.js",           // output path for CommonJS/Node
  "module": "dist/foo.module.js",  // output path for JS Modules
  "unpkg": "dist/foo.umd.js",      // optional, for unpkg.com
  "scripts": {
    "build": "microbundle",        // uses "source" and "main" as input and output paths by default
    "dev": "microbundle watch"
  }
}
```