### PR TITLE
adjust typing to mirror changes in getAccessToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ client
   .catch(console.error);
 ```
 
-Then you redirect your user to `https://api.twitter.com/oauth/authenticate?oauth_token=xyz123abc`, and once you get the verifier and the token, you pass them on to the next stage of the authentication.
+Then you redirect your user to `https://api.twitter.com/oauth/authenticate?oauth_token=xyz123abc`, and once you get the verifier and the token, you pass them on to the [next stage of the authentication](https://developer.twitter.com/en/docs/basics/authentication/api-reference/access_token).
 
 ```es6
 const client = new Twitter({
@@ -145,9 +145,8 @@ const client = new Twitter({
 
 client
   .getAccessToken({
-    key: requestToken,
-    secret: requestTokenSecret,
-    verifier: oauthVerifier
+    oauth_verifier: oauthVerifier,
+    oauth_token: oauthToken
   })
   .then(res =>
     console.log({

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,8 +47,9 @@ declare namespace TwitterLite {
   }
 
   interface AccessTokenOptions extends KeySecret {
-    /** If using the OAuth web-flow, set this parameter to the value of the oauth_verifier returned in the callback URL. If you are using out-of-band OAuth, set this value to the pin-code. */
-    verifier: string | number;
+    /** If using the OAuth web-flow, set these parameters to the values returned in the callback URL. If you are using out-of-band OAuth, set this value to the pin-code. */
+    oauth_verifier: string | number;
+    oauth_token: string | number;
   }
 
   interface BearerResponse {

--- a/index.d.ts
+++ b/index.d.ts
@@ -49,7 +49,7 @@ declare namespace TwitterLite {
   interface AccessTokenOptions extends KeySecret {
     /** If using the OAuth web-flow, set these parameters to the values returned in the callback URL. If you are using out-of-band OAuth, set this value to the pin-code. */
     oauth_verifier: string | number;
-    oauth_token: string | number;
+    oauth_token?: string;
   }
 
   interface BearerResponse {

--- a/index.d.ts
+++ b/index.d.ts
@@ -46,10 +46,11 @@ declare namespace TwitterLite {
     secret: string;
   }
 
-  interface AccessTokenOptions extends KeySecret {
-    /** If using the OAuth web-flow, set these parameters to the values returned in the callback URL. If you are using out-of-band OAuth, set this value to the pin-code. */
+  interface AccessTokenOptions {
+    /** If using the OAuth web-flow, set these parameters to the values returned in the callback URL. If you are using out-of-band OAuth, set the value of oauth_verifier to the pin-code.
+     * The oauth_token here must be the same as the oauth_token returned in the request_token step.*/
     oauth_verifier: string | number;
-    oauth_token?: string;
+    oauth_token: string;
   }
 
   interface BearerResponse {

--- a/twitter.js
+++ b/twitter.js
@@ -174,7 +174,7 @@ class Twitter {
     };
 
     let parameters = { oauth_verifier: options.oauth_verifier, oauth_token: options.oauth_token };
-    if (parameters.oauth_verifier && parameters.oauth_token) requestData.url += '?' + querystring.stringify(parameters);
+    if (parameters.oauth_verifier) requestData.url += '?' + querystring.stringify(parameters);
 
     const headers = this.client.toHeader(
       this.client.authorize(requestData, {

--- a/twitter.js
+++ b/twitter.js
@@ -174,14 +174,9 @@ class Twitter {
     };
 
     let parameters = { oauth_verifier: options.oauth_verifier, oauth_token: options.oauth_token };
-    if (parameters.oauth_verifier) requestData.url += '?' + querystring.stringify(parameters);
+    if (parameters.oauth_verifier && parameters.oauth_token) requestData.url += '?' + querystring.stringify(parameters);
 
-    const headers = this.client.toHeader(
-      this.client.authorize(requestData, {
-        key: options.key,
-        secret: options.secret,
-      }),
-    );
+    const headers = this.client.toHeader( this.client.authorize(requestData) );
 
     const results = await Fetch(requestData.url, {
       method: 'POST',


### PR DESCRIPTION
As corrected in #79 , the inputs have changed. 
After remembering that typing had been added, the types needed to also be adjusted. This PR takes care of that.

After looking at the documentation again, I could confirm my assumption that key and secret are not part of the request.
Therefore the type and function have been adjusted to include this change.
