### PR TITLE
Change request_token response type to have boolean strings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -157,9 +157,9 @@ type TokenResponse =
   | {
       oauth_token: OauthToken;
       oauth_token_secret: OauthTokenSecret;
-      oauth_callback_confirmed: true;
+      oauth_callback_confirmed: 'true';
     }
-  | { oauth_callback_confirmed: false };
+  | { oauth_callback_confirmed: 'false' };
 
 interface AccessTokenResponse {
   oauth_token: string;


### PR DESCRIPTION
I noticed that a comparison to boolean wasn't having the anticipated results discovered that the Typescript types for this part of `TokenResponse` seem to be incorrectly typed as boolean, when they should be strings. This is because the response is parsed by `querystring`, which parses a string like `oauth_token=cxQNEQAAAAABDlRSAAABcirMJDU&oauth_token_secret=nottherealsecret&oauth_callback_confirmed=true` to an object with all string values.