### PR TITLE
fix: Fix TokenResponse Type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -135,6 +135,7 @@ interface TwitterOptions {
 type OauthToken = string;
 type OauthTokenSecret = string;
 type AuthType = 'App' | 'User';
+type BoolStr = 'true' | 'false';
 
 interface KeySecret {
   key: string;
@@ -153,13 +154,11 @@ interface BearerResponse {
   access_token: string;
 }
 
-type TokenResponse =
-  | {
-      oauth_token: OauthToken;
-      oauth_token_secret: OauthTokenSecret;
-      oauth_callback_confirmed: 'true';
-    }
-  | { oauth_callback_confirmed: 'false' };
+interface TokenResponse {
+  oauth_token?: OauthToken;
+  oauth_token_secret?: OauthTokenSecret;
+  oauth_callback_confirmed: BoolStr;
+}
 
 interface AccessTokenResponse {
   oauth_token: string;


### PR DESCRIPTION
- The TokenResponse type was unioning to different types and so only
  the shared keys, oauth_callback_confirmed, were actually available as
  keys on that type
- This change switches TokenResponse back to an interface and uses
  optional properties for keys that may not be present

## Notes

- This fix resolved a typing error for me where the following wouldn't work:

```js
// Property 'oauth_token' does not exist on type 'TokenResponse'.ts(2339)
const { oauth_token } = await client.getRequestToken("http://localhost:4000/auth/callback/twitter")
```

- That said, I'm new to typescript so I apologize if there is a more standard way to handle this