### PR TITLE
Make consumer_key and consumer_secret optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -123,9 +123,9 @@ interface TwitterOptions {
   /** version "1.1" is the default (change for other subdomains) */
   version?: string;
   /** consumer key from Twitter. */
-  consumer_key: string;
+  consumer_key?: string;
   /** consumer secret from Twitter */
-  consumer_secret: string;
+  consumer_secret?: string;
   /** access token key from your User (oauth_token) */
   access_token_key?: OauthToken;
   /** access token secret from your User (oauth_token_secret) */


### PR DESCRIPTION
They should not be required because a `bearer_token` can be sufficient.