### PR TITLE
Add default import in twitter.js

### DIFF
--- a/twitter.js
+++ b/twitter.js
@@ -354,3 +354,5 @@ class Twitter {
 }
 
 module.exports = Twitter;
+
+Twitter.default = Twitter;


### PR DESCRIPTION
There declaration in `index.d.ts`
```ts
export default class Twitter {
```
But without this PR it is impossible to import this way
```ts
import Twitter from 'twitter-lite'
```
Because for exporting
```js
module.exports = Twitter
```
Import must looks like
```ts
import * as Twitter from 'twitter-lite'
```
But it's not described in `index.d.ts`