### PR TITLE
Add support for Twitter api v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,21 @@ process.nextTick(() => stream.destroy());
 
 After calling `stream.destroy()`, you can recreate the stream, if you wait long enough - see the "should reuse stream N times" test. Note that Twitter may return a "420 Enhance your calm" error if you switch streams too fast. There are no response headers specifying how long to wait, and [the error](https://stackoverflow.com/questions/13438965/avoid-420s-with-streaming-api), as well as [streaming limits](https://stackoverflow.com/questions/34962677/twitter-streaming-api-limits) in general, are poorly documented. Trial and error has shown that for tracked keywords, waiting 20 to 30 seconds between re-creating streams was enough. Remember to also set up the `.on()` handlers again for the new stream.
 
+## Support for Twitter API v2
+
+The new Twitter API v2 no longer requires the `.json` extension on its endpoints. In order to use `v2`, set `version: '2'` and `extension: false`.
+
+```es6
+const client = new Twitter({
+  version: "2", // version "1.1" is the default (change for v2)
+  extension: false, // true is the default (this must be set to false for v2 endpoints)
+  consumer_key: "abc", // from Twitter.
+  consumer_secret: "def", // from Twitter.
+  access_token_key: "uvw", // from your User (oauth_token)
+  access_token_secret: "xyz" // from your User (oauth_token_secret)
+});
+```
+
 ## Methods
 
 ### .get(endpoint, parameters)

--- a/index.d.ts
+++ b/index.d.ts
@@ -122,6 +122,8 @@ interface TwitterOptions {
   subdomain?: string;
   /** version "1.1" is the default (change for other subdomains) */
   version?: string;
+  /** version "2" does not use .json for endpoints, defaults to true */
+  extension?: boolean;
   /** consumer key from Twitter. */
   consumer_key: string;
   /** consumer secret from Twitter */

--- a/twitter.js
+++ b/twitter.js
@@ -30,6 +30,7 @@ const defaults = {
   access_token_secret: null,
   bearer_token: null,
   version: '1.1',
+  extension: true,
 };
 
 // Twitter expects POST body parameters to be URL-encoded: https://developer.twitter.com/en/docs/basics/authentication/guides/creating-a-signature
@@ -201,7 +202,7 @@ class Twitter {
    */
   _makeRequest(method, resource, parameters) {
     const requestData = {
-      url: `${this.url}/${resource}.json`,
+      url: `${this.url}/${resource}${this.config.extension ? '.json' : ''}`,
       method,
     };
     if (parameters)
@@ -313,7 +314,7 @@ class Twitter {
     // POST the request, in order to accommodate long parameter lists, e.g.
     // up to 5000 ids for statuses/filter - https://developer.twitter.com/en/docs/tweets/filter-realtime/api-reference/post-statuses-filter
     const requestData = {
-      url: `${getUrl('stream')}/${resource}.json`,
+      url: `${getUrl('stream')}/${resource}${this.config.extension ? '.json' : ''}`,
       method: 'POST',
     };
     if (parameters) requestData.data = parameters;


### PR DESCRIPTION
The new Twitter API v2 doesn't use the `.json` extension for its endpoints (e.g. https://developer.twitter.com/en/docs/twitter-api/tweets/lookup/api-reference).

This pull request adds a boolean `extension` option that can disable the `.json` extension by setting it to `false`. Existing users will not be affected as it defaults to `true`. 