### PR TITLE
Allow extra options passed to `Fetch

### DIFF
--- a/twitter.js
+++ b/twitter.js
@@ -129,7 +129,7 @@ class Twitter {
     }
   }
 
-  async getBearerToken() {
+  async getBearerToken(fetchOptions = {}) {
     const headers = {
       Authorization:
         'Basic ' +
@@ -143,12 +143,13 @@ class Twitter {
       method: 'POST',
       body: 'grant_type=client_credentials',
       headers,
+      ...fetchOptions,
     }).then(Twitter._handleResponse);
 
     return results;
   }
 
-  async getRequestToken(twitterCallbackUrl) {
+  async getRequestToken(twitterCallbackUrl, fetchOptions = {}) {
     const requestData = {
       url: `${this.oauth}/request_token`,
       method: 'POST',
@@ -165,13 +166,14 @@ class Twitter {
     const results = await Fetch(requestData.url, {
       method: 'POST',
       headers: Object.assign({}, baseHeaders, headers),
+      ...fetchOptions,
     })
       .then(Twitter._handleResponseTextOrJson);
 
     return results;
   }
 
-  async getAccessToken(options) {
+  async getAccessToken(options, fetchOptions = {}) {
     const requestData = {
       url: `${this.oauth}/access_token`,
       method: 'POST',
@@ -185,6 +187,7 @@ class Twitter {
     const results = await Fetch(requestData.url, {
       method: 'POST',
       headers: Object.assign({}, baseHeaders, headers),
+      ...fetchOptions,
     })
       .then(Twitter._handleResponseTextOrJson);
 
@@ -228,17 +231,18 @@ class Twitter {
    * Send a GET request
    * @param {string} resource - endpoint, e.g. `followers/ids`
    * @param {object} [parameters] - optional parameters
+   * @param {object=} fetchOptions - options forwarded to `Fetch`
    * @returns {Promise<object>} Promise resolving to the response from the Twitter API.
    *   The `_header` property will be set to the Response headers (useful for checking rate limits)
    */
-  get(resource, parameters) {
+  get(resource, parameters, fetchOptions = {}) {
     const { requestData, headers } = this._makeRequest(
       'GET',
       resource,
       parameters,
     );
 
-    return Fetch(requestData.url, { headers })
+    return Fetch(requestData.url, { headers, ...fetchOptions })
       .then(Twitter._handleResponse);
   }
 
@@ -247,10 +251,11 @@ class Twitter {
    * @param {string} resource - endpoint, e.g. `users/lookup`
    * @param {object} body - POST parameters object.
    *   Will be encoded appropriately (JSON or urlencoded) based on the resource
+   * @param {object=} fetchOptions - options forwarded to `Fetch`
    * @returns {Promise<object>} Promise resolving to the response from the Twitter API.
    *   The `_header` property will be set to the Response headers (useful for checking rate limits)
    */
-  post(resource, body) {
+  post(resource, body, fetchOptions = {}) {
     const { requestData, headers } = this._makeRequest(
       'POST',
       resource,
@@ -269,6 +274,7 @@ class Twitter {
       method: 'POST',
       headers: postHeaders,
       body,
+      ...fetchOptions,
     })
       .then(Twitter._handleResponse);
   }
@@ -278,9 +284,10 @@ class Twitter {
    * @param {string} resource - endpoint e.g. `direct_messages/welcome_messages/update`
    * @param {object} parameters - required or optional query parameters
    * @param {object} body - PUT request body 
+   * @param {object=} fetchOptions - options forwarded to `Fetch`
    * @returns {Promise<object>} Promise resolving to the response from the Twitter API.
    */
-  put(resource, parameters, body) {
+  put(resource, parameters, body, fetchOptions = {}) {
     const { requestData, headers } = this._makeRequest(
       'PUT',
       resource,
@@ -294,6 +301,7 @@ class Twitter {
       method: 'PUT',
       headers: putHeaders,
       body,
+      ...fetchOptions,
     })
       .then(Twitter._handleResponse);
   }
@@ -302,9 +310,10 @@ class Twitter {
    *
    * @param {string} resource - endpoint, e.g. `statuses/filter`
    * @param {object} parameters
+   * @param {object=} fetchOptions - options forwarded to `Fetch`
    * @returns {Stream}
    */
-  stream(resource, parameters) {
+  stream(resource, parameters, fetchOptions = {}) {
     if (this.authType !== 'User')
       throw new Error('Streams require user context authentication');
 
@@ -329,6 +338,7 @@ class Twitter {
         'Content-Type': 'application/x-www-form-urlencoded',
       },
       body: percentEncode(querystring.stringify(parameters)),
+      ...fetchOptions,
     });
 
     request


### PR DESCRIPTION
This allows the user to pass custom parameters directly to `Fetch` when calling Twitter endpoints. Addresses #114