### PR TITLE
Fix TwitterOptions interface typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -125,9 +125,9 @@ interface TwitterOptions {
   /** version "2" does not use .json for endpoints, defaults to true */
   extension?: boolean;
   /** consumer key from Twitter. */
-  consumer_key: string;
+  consumer_key?: string;
   /** consumer secret from Twitter */
-  consumer_secret: string;
+  consumer_secret?: string;
   /** access token key from your User (oauth_token) */
   access_token_key?: OauthToken;
   /** access token secret from your User (oauth_token_secret) */


### PR DESCRIPTION
As shown in the [README](https://github.com/draftbit/twitter-lite#app-authentication-example), when using the App Authentication model, consumer key and consumer secret is completely unneeded on the final instance of the Twitter class.

This tiny change corrects the "property is missing" Typescript error on that use case.