### PR TITLE
Added support for media/upload & tweets

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
   ],
   "dependencies": {
     "cross-fetch": "^3.0.0",
-    "oauth-1.0a": "^2.2.4"
+    "get-random-values": "^1.2.2",
+    "oauth-1.0a": "^2.2.4",
+    "oauth-signature": "^1.5.0"
   },
   "devDependencies": {
     "@types/jest": "^25.2.1",


### PR DESCRIPTION
Added support for the following endpoints:

```
POST media/upload [v1.1]
POST tweets [v2]
```

_media/upload_ requires that the **oAuth** data including:

- oauth_consumer_key
- oauth_nonce [requires _get-random-values_ library]
- oauth_signature [requires _oauth-signature_ library]
- oauth_signature_method
- oauth_timestamp
- oauth_token
- oauth_version

And the _Base64_ encoded binary image data:

- media_data

To be placed in the **body**

The only **headers** required are:

- Content-Transfer-Encoding = base64
- Content-Type = application/x-www-form-urlencoded

![postman-twitter-media-upload-auth](https://user-images.githubusercontent.com/827046/145479958-a17ada23-e17c-4b3a-af2c-a84d4bb5d8e3.png)

![postman-twitter-media-upload-headers](https://user-images.githubusercontent.com/827046/145480405-7defe44d-4628-4356-83f4-021c78baab50.png)

![postman-twitter-media-upload-body](https://user-images.githubusercontent.com/827046/145481115-629b5b15-635e-4ffe-a69d-3eb70e88040d.png)

